### PR TITLE
Fix loading animation surviving after login failure

### DIFF
--- a/main.py
+++ b/main.py
@@ -38,12 +38,14 @@ class App(ctk.CTk):
             ["python3", f"{Path(__file__).parent / 'loading.py'}"]
         )
 
-        self.account = login(
-            username,
-            passwd,
-            domain if domain else "sisstudent.fcps.edu/SVUE"
-        )
-        loading.terminate()
+        try:
+            self.account = login(
+                username,
+                passwd,
+                domain if domain else "sisstudent.fcps.edu/SVUE"
+            )
+        finally:
+            loading.terminate()
         self.choose_classes()
         self.mainloop()
         self.assignment_gui()


### PR DESCRIPTION
If you fail to login, the loading animation would continue to be played, as the process is never terminated.
This PR fixes that using `try ... finally`
